### PR TITLE
Do not compile pre-signed kernels

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,6 +65,5 @@ jobs:
             Kernel Delivery System - Triggered by ${{ github.sha }} at ${{ github.event.repository.updated_at }}
           files: |
             bzImage
-            bzImage.signed
             modules.tar.xz
             headers.tar.xz

--- a/build.sh
+++ b/build.sh
@@ -75,17 +75,6 @@ fi
 cp arch/x86/boot/bzImage ../$VMLINUZ
 echo "bzImage and modules built"
 
-# Sign the kernel
-futility --debug vbutil_kernel \
-    --arch x86_64 --version 1 \
-    --keyblock /usr/share/vboot/devkeys/kernel.keyblock \
-    --signprivate /usr/share/vboot/devkeys/kernel_data_key.vbprivk \
-    --bootloader ../kernel.flags \
-    --config ../kernel.flags \
-    --vmlinuz ../$VMLINUZ \
-    --pack ../${VMLINUZ}.signed
-echo "Signed bzImage created\!" # Shell expansion weirdness
-
 rm -rf mod || true
 mkdir mod
 make -j$(nproc) modules_install INSTALL_MOD_PATH=mod

--- a/kernel.flags
+++ b/kernel.flags
@@ -1,1 +1,0 @@
-console=tty1 root=/dev/sda2 i915.modeset=1 rootwait rw fbcon=logo-pos:center,logo-count:1 loglevel=0 iommu=pt splash


### PR DESCRIPTION
The install scripts all compile kernels locally, due to using PARTUUIDs, which cannot be hardcoded. I suggest removing signed kernels build, as users may try and flash a presigned kernel.